### PR TITLE
avoid cpu roasting

### DIFF
--- a/pixelhasher.cu
+++ b/pixelhasher.cu
@@ -245,11 +245,13 @@ int solve_work(uint8_t *full_solution) {
     print_art32(initial_hash_input + 52);
     printf("^^^^^^^^^^^^^^^^\n");
 
+    cudaStream_t d;
+    cudaStreamCreate(&d);
     cudaMemcpy(d_initial_hash_input, initial_hash_input, LEN84_INPUT, cudaMemcpyHostToDevice);
     runtime = now();
-    launch<<<NUMBER_BLOCKS, NUMBER_THREADS>>>(d_mining_target, d_initial_hash_input, d_winning_hash_input, d_done);
+    launch<<<NUMBER_BLOCKS, NUMBER_THREADS, 0, d>>>(d_mining_target, d_initial_hash_input, d_winning_hash_input, d_done);
     starting_tid += NUMBER_BLOCKS * NUMBER_THREADS;
-    // TODO: fix cpu 100% bug like this: https://forums.developer.nvidia.com/t/100-cpu-usage-when-running-cuda-code/35920/6
+    while (cudaStreamQuery(d) != cudaSuccess) { usleep(50000); }
     cudaerr  = cudaDeviceSynchronize();
     runtime = now() - runtime;
     cudaMemcpy(h_done, d_done, sizeof(int), cudaMemcpyDeviceToHost);


### PR DESCRIPTION
call `cudaDeviceSynchronize()` only after we know work is done.

lowers cpu usage from 100% to 0.1%